### PR TITLE
`IncludeAssets` property for the MAUI Blazor package in MCL

### DIFF
--- a/src/NET_10/MauiApp3/MauiApp3.MauiLib/MauiApp3.MauiLib.csproj
+++ b/src/NET_10/MauiApp3/MauiApp3.MauiLib/MauiApp3.MauiLib.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" IncludeAssets="compile;runtime" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.*-*" Condition="'$(Configuration)' == 'Debug'" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     </ItemGroup>

--- a/src/NET_10/MauiApp3/MauiApp3/wwwroot/index.html
+++ b/src/NET_10/MauiApp3/MauiApp3/wwwroot/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="css/font-awesome/css/all.min.css" />
     <link href="css/app.css" rel="stylesheet" />
-    <link href="MauiApp3.MauiLib.styles.css" rel="stylesheet" />
+    <link href="MauiApp3.styles.css" rel="stylesheet" />
     <style>
         html {
             height: 100%;

--- a/src/NET_9/MauiApp3/MauiApp3.MauiLib/MauiApp3.MauiLib.csproj
+++ b/src/NET_9/MauiApp3/MauiApp3.MauiLib/MauiApp3.MauiLib.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" IncludeAssets="compile;runtime" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.*" Condition="'$(Configuration)' == 'Debug'" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     </ItemGroup>

--- a/src/NET_9/MauiApp3/MauiApp3/wwwroot/index.html
+++ b/src/NET_9/MauiApp3/MauiApp3/wwwroot/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="css/font-awesome/css/all.min.css" />
     <link href="css/app.css" rel="stylesheet" />
-    <link href="MauiApp3.MauiLib.styles.css" rel="stylesheet" />
+    <link href="MauiApp3.styles.css" rel="stylesheet" />
     <style>
         html {
             height: 100%;


### PR DESCRIPTION
**Changes:**

Now, `index.html` will refer to the CSS from the app itself and add `IncludeAssets` property in the MCL project file.

```xml
<PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" IncludeAssets="compile;runtime" />
```